### PR TITLE
Fix zero byte book produced by "polyglot make-book"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Please keep each section in ASCII (LC_ALL=C sort) order.
+
+# File patterns to ignore. This applies recursively to all subdirectories.
+*.o
+.depend
+
+# Per directory patterns to ignore. These do not apply recursively to
+# subdirectories. Each line should begin with "[!]/". Please keep the
+# directories in depth first order followed by ASCII (LC_ALL=C sort) order.
+
+/src/polyglot

--- a/src/book_make.cpp
+++ b/src/book_make.cpp
@@ -202,13 +202,7 @@ void book_make(int argc, char * argv[]) {
         book_sort();
 
         printf("saving entries ...\n");
-//        if (Storage == LEVELDB) {
-//                printf("Saving to leveldb.. \n");
-//                book_save(NULL, leveldb_file);
-//        }
-//        else {
         book_save(bin_file, NULL);
-//        }
     }
 
    
@@ -349,32 +343,19 @@ static void book_insert(const char file_name[], const char leveldb_file_name[]) 
 
             pos = find_entry(board,move);
 
-//            if (Storage==POLYGLOT) {
-//            Book->entry[pos].n++;
-//            Book->entry[pos].sum += result+1;
-            Book->entry[pos].game_ids->insert(game_nb);
-
+            if (leveldb_file_name!=NULL) {
+                Book->entry[pos].game_ids->insert(game_nb);
+            }
+            else {
+                Book->entry[pos].n++;
+                Book->entry[pos].sum += result+1;
+            
+            }
+            
 //            if (Book->entry[pos].n >= COUNT_MAX) {
+//                
 //                halve_stats(board->key);
 //            }
-//            }
-//            else {
-//                std::stringstream game_id_stream;
-//                std::string currentValue;
-//                leveldb::Status s = db->Get(leveldb::ReadOptions(), uint64_to_string(board->key), &currentValue);
-//                if (s.ok()) {
-//                    game_id_stream << currentValue;
-//                }
-//                
-//                game_id_stream << game_nb << ",";
-////                for (set<int>::iterator it = Book->entry[pos].game_ids->begin(); it != Book->entry[pos].game_ids->end(); ++it) {
-////                    game_id_stream << *it << ",";
-////                }
-////                writeBatch.Put(uint64_to_string(board->key), game_id_stream.str());
-////                db->Put(writeOptions, uint64_to_string(board->key), game_id_stream.str());
-//                
-//              }
-
            
             move_do(board,move);
             ply++;            
@@ -682,7 +663,7 @@ static bool keep_entry(int pos) {
 
    entry = &Book->entry[pos];
 
-   // if (entry->n == 0) return false;
+//   if (entry->n == 0) return false;
    if (entry->n < MinGame) return false;
 
    if (entry->sum == 0) return false;


### PR DESCRIPTION
I don't quite understand the intent of the commit in question, but I do know that it breaks `polyglot make-book` in latest master, which means that  `polyglot make-book` is broken in at least Fedora 33.

To reproduce:
```
polyglot make-book -pgn fools-mate.pgn -bin fools-mate.bin -min-game 1
```
which produces a 80 byte file with this fix, and zero byte otherwise. The problem has to do with entries incorrectly being filtered. Consider these two output lines in the 80 byte fixed case:
```
filtering entries ...
5 entries.
```
and in the zero byte broken case:
```
filtering entries ...
0 entries.
```

This merge request probably isn't suitable as is, but it's at least a starting point for people trying to figure out `polyglot make-book` on Linux.

Also, I included a `.gitignore` - all of the `*.o` files show up as untracked files otherwise.

The `fools-mate.pgn` mentioned above:
```
[Event "Black wins"]
[Site "cube"]
[Date "2020.12.15"]
[Round "-"]
[White "-"]
[Black "-"]
[Result "0-1"]

1. f3 e6 2. g4 Qh4# 0-1

[Event "White wins"]
[Site "cube"]
[Date "2020.12.15"]
[Round "-"]
[White "-"]
[Black "-"]
[Result "1-0"]

1. e4 f6 2. d4 g5 3. Qh5# 1-0
```